### PR TITLE
Fix pluralizing for action name

### DIFF
--- a/src/syno/Utils.coffee
+++ b/src/syno/Utils.coffee
@@ -76,8 +76,7 @@ class Utils
     # `str` [String]
     @listPluralize = (method, apiSubNname) ->
         if startsWith(method.toLowerCase(), 'list') and not endsWith(apiSubNname, 's')
-            lastWord = last(apiSubNname.split(/(?=[A-Z][^A-Z]+$)/))
-            apiSubNname = pluralize(lastWord) # pluralize if list
+            apiSubNname = apiSubNname.replace(/([A-Z][^A-Z]+)$/, (_, last) -> pluralize(last)) # pluralize if list
         return apiSubNname
         
     @createFunctionName = (apiName, method) ->


### PR DESCRIPTION
Fix hiding api form one submodule to another. For example `dl listTasks` try to get `DownloadStation.Xunlei.Task` api instead `DownloadStation.Task`. Now `Xunlei` has own method `listXunleiTask`.

Resolves #25 