### PR TITLE
When response is not "text/plain"

### DIFF
--- a/dist/syno.js
+++ b/dist/syno.js
@@ -74,7 +74,7 @@
                         error.response = response;
                         return done(error);
                       }
-                      if (!body.success || (body.success && body.data && body.data instanceof Array && body.data[0] && body.data[0].error)) {
+                      if ( response.headers["content-type"]=='text/plain; charset="UTF-8"' && (!body.success || (body.success && body.data && body.data instanceof Array && body.data[0] && body.data[0].error)) ) {
                         code = body.error ? body.error.code : body.data[0].error;
                         error = new Error(_this.error(code, api));
                         error.code = code;


### PR DESCRIPTION
If response is not "text/plain" like "image/jpeg" do not try to get error in data result.